### PR TITLE
Trufflehog improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3-alpine
-RUN apk add --no-cache git && pip install gitdb2==3.0.0 trufflehog
+RUN apk add --no-cache git && pip install gitdb2==3.0.0 GitPython==3.0.6 truffleHogRegexes==0.0.7
 RUN adduser -S truffleHog
 USER truffleHog
+COPY truffleHog/truffleHog.py /usr/local/bin/trufflehog
 WORKDIR /proj
 ENTRYPOINT [ "trufflehog" ]
 CMD [ "-h" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM python:3-alpine
 RUN apk add --no-cache git && pip install gitdb2==3.0.0 GitPython==3.0.6 truffleHogRegexes==0.0.7
-RUN adduser -S truffleHog
-USER truffleHog
 COPY truffleHog/truffleHog.py /usr/local/bin/trufflehog
 WORKDIR /proj
 ENTRYPOINT [ "trufflehog" ]

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ https://join.slack.com/t/trufflehog-community/shared_invite/zt-nzznzf8w-y1Lg4Pnn
 truffleHog previously functioned by running entropy checks on git diffs. This functionality still exists, but high signal regex checks have been added, and the ability to suppress entropy checking has also been added.
 
 
-```
+```bash
 truffleHog --regex --entropy=False https://github.com/dxa4481/truffleHog.git
 ```
 
 or
 
-```
+```bash
 truffleHog file:///user/dxa4481/codeprojects/truffleHog/
 ```
 
@@ -55,14 +55,14 @@ These features help cut down on noise, and makes the tool easier to shove into a
 ![Example](https://i.imgur.com/YAXndLD.png)
 
 ## Install
-```
+```bash
 pip install truffleHog
 ```
 
 ## Customizing
 
 Custom regexes can be added with the following flag `--rules /path/to/rules`. This should be a json file of the following format:
-```
+```json
 {
     "RSA private key": "-----BEGIN EC PRIVATE KEY-----"
 }
@@ -74,7 +74,7 @@ Feel free to also contribute high signal regexes upstream that you think will be
 trufflehog's base rule set sources from https://github.com/dxa4481/truffleHogRegexes/blob/master/truffleHogRegexes/regexes.json
 
 To explicitly allow particular secrets (e.g. self-signed keys used only for local testing) you can provide an allow list `--allow /path/to/allow` in the following format:
-```
+```json
 {
     "local self signed test key": "-----BEGIN EC PRIVATE KEY-----\nfoobar123\n-----END EC PRIVATE KEY-----",
     "git cherry pick SHAs": "regex:Cherry picked from .*",
@@ -89,10 +89,15 @@ This module will go through the entire commit history of each branch, and check 
 ## Help
 
 ```
-usage: trufflehog [-h] [--json] [--regex] [--rules RULES] [--allow ALLOW]
-                  [--entropy DO_ENTROPY] [--since_commit SINCE_COMMIT]
-                  [--max_depth MAX_DEPTH]
-                  git_url
+usage: truffleHog.py [-h] [--json] [--format {NONE,TERSE,FULL,JSON}] [--regex]
+                     [--rules RULES] [--allow ALLOW] [--entropy DO_ENTROPY]
+                     [--since_commit SINCE_COMMIT] [--max_depth MAX_DEPTH]
+                     [--branch BRANCH] [-i INCLUDE_PATHS_FILE]
+                     [-x EXCLUDE_PATHS_FILE] [--repo_path REPO_PATH]
+                     [--cleanup]
+                     [--log {CRITICAL,FATAL,ERROR,WARN,WARNING,INFO,DEBUG,NOTSET}]
+                     [--log_file LOG_FILE]
+                     git_url
 
 Find secrets hidden in the depths of git.
 
@@ -101,17 +106,23 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
-  --json                Output in JSON
+  --json                Output in JSON format, equivalent to --format=JSON
+  --format {NONE,TERSE,FULL,JSON}
+                        Format for result output; NONE No output, TERSE First
+                        line of commit message and only matching lines from
+                        the diff, FULL Entire commit message and entire diff,
+                        JSON Entire commit message and entire diff in JSON
+                        format
   --regex               Enable high signal regex checks
-  --rules RULES         Ignore default regexes and source from json list file
+  --rules RULES         Ignore default regexes and source from json file
   --allow ALLOW         Explicitly allow regexes from json list file
   --entropy DO_ENTROPY  Enable entropy checks
   --since_commit SINCE_COMMIT
                         Only scan from a given commit hash
-  --branch BRANCH       Scans only the selected branch
   --max_depth MAX_DEPTH
                         The max commit depth to go back when searching for
                         secrets
+  --branch BRANCH       Name of the branch to be scanned
   -i INCLUDE_PATHS_FILE, --include_paths INCLUDE_PATHS_FILE
                         File with regular expressions (one per line), at least
                         one of which must match a Git object path in order for
@@ -126,19 +137,26 @@ optional arguments:
                         comments and are ignored. If empty or not provided
                         (default), no Git object paths are excluded unless
                         effectively excluded via the --include_paths option.
+  --repo_path REPO_PATH
+                        Path to the cloned repo. If provided, git_url will not
+                        be used
+  --cleanup             Clean up all temporary result files
+  --log {CRITICAL,FATAL,ERROR,WARN,WARNING,INFO,DEBUG,NOTSET}
+                        Set logging level
+  --log_file LOG_FILE   Write log to file
 ```
 
 ## Running with Docker
 
 First, enter the directory containing the git repository
 
-```
+```bash
 cd /path/to/git
 ```
 
 To launch the trufflehog with the docker image, run the following"
 
-```
+```bash
 docker run --rm -v "$(pwd):/proj" dxa4481/trufflehog file:///proj
 ```
 

--- a/test_all.py
+++ b/test_all.py
@@ -52,7 +52,7 @@ class TestStringMethods(unittest.TestCase):
         sys.stdout = tmp_stdout
         try:
             truffleHog.find_strings("https://github.com/dxa4481/truffleHog.git", 
-                since_commit=since_commit, printJson=True, surpress_output=False)
+                since_commit=since_commit, output_format=truffleHog.OutputFormat.JSON)
         finally:
             sys.stdout = bak_stdout
 
@@ -73,6 +73,7 @@ class TestStringMethods(unittest.TestCase):
         repo_const_mock.return_value = repo
         truffleHog.find_strings("test_repo", branch="testbranch")
         repo.remotes.origin.fetch.assert_called_once_with("testbranch")
+
     def test_path_included(self):
         Blob = namedtuple('Blob', ('a_path', 'b_path'))
         blobs = {
@@ -96,42 +97,43 @@ class TestStringMethods(unittest.TestCase):
         sub_dirs_patterns = [re.compile(r'.+/.+')]
         deleted_paths_patterns = [re.compile(r'(.*/)?deleted-file$')]
         for name, blob in blobs.items():
-            self.assertTrue(truffleHog.path_included(blob),
+            blob_path = truffleHog.blob_path(blob)
+            self.assertTrue(truffleHog.path_included(blob_path),
                             '{} should be included by default'.format(blob))
-            self.assertTrue(truffleHog.path_included(blob, include_patterns=all_paths_patterns),
+            self.assertTrue(truffleHog.path_included(blob_path, include_patterns=all_paths_patterns),
                             '{} should be included with include_patterns: {}'.format(blob, all_paths_patterns))
-            self.assertFalse(truffleHog.path_included(blob, exclude_patterns=all_paths_patterns),
+            self.assertFalse(truffleHog.path_included(blob_path, exclude_patterns=all_paths_patterns),
                              '{} should be excluded with exclude_patterns: {}'.format(blob, all_paths_patterns))
-            self.assertFalse(truffleHog.path_included(blob,
+            self.assertFalse(truffleHog.path_included(blob_path,
                                                       include_patterns=all_paths_patterns,
                                                       exclude_patterns=all_paths_patterns),
                              '{} should be excluded with overlapping patterns: \n\tinclude: {}\n\texclude: {}'.format(
                                  blob, all_paths_patterns, all_paths_patterns))
-            self.assertFalse(truffleHog.path_included(blob,
+            self.assertFalse(truffleHog.path_included(blob_path,
                                                       include_patterns=overlap_patterns,
                                                       exclude_patterns=all_paths_patterns),
                              '{} should be excluded with overlapping patterns: \n\tinclude: {}\n\texclude: {}'.format(
                                  blob, overlap_patterns, all_paths_patterns))
-            self.assertFalse(truffleHog.path_included(blob,
+            self.assertFalse(truffleHog.path_included(blob_path,
                                                       include_patterns=all_paths_patterns,
                                                       exclude_patterns=overlap_patterns),
                              '{} should be excluded with overlapping patterns: \n\tinclude: {}\n\texclude: {}'.format(
                                  blob, all_paths_patterns, overlap_patterns))
             path = blob.b_path if blob.b_path else blob.a_path
             if '/' in path:
-                self.assertTrue(truffleHog.path_included(blob, include_patterns=sub_dirs_patterns),
+                self.assertTrue(truffleHog.path_included(blob_path, include_patterns=sub_dirs_patterns),
                                 '{}: inclusion should include sub directory paths: {}'.format(blob, sub_dirs_patterns))
-                self.assertFalse(truffleHog.path_included(blob, exclude_patterns=sub_dirs_patterns),
+                self.assertFalse(truffleHog.path_included(blob_path, exclude_patterns=sub_dirs_patterns),
                                  '{}: exclusion should exclude sub directory paths: {}'.format(blob, sub_dirs_patterns))
             else:
-                self.assertFalse(truffleHog.path_included(blob, include_patterns=sub_dirs_patterns),
+                self.assertFalse(truffleHog.path_included(blob_path, include_patterns=sub_dirs_patterns),
                                  '{}: inclusion should exclude root directory paths: {}'.format(blob, sub_dirs_patterns))
-                self.assertTrue(truffleHog.path_included(blob, exclude_patterns=sub_dirs_patterns),
+                self.assertTrue(truffleHog.path_included(blob_path, exclude_patterns=sub_dirs_patterns),
                                 '{}: exclusion should include root directory paths: {}'.format(blob, sub_dirs_patterns))
             if name.startswith('deleted-file-'):
-                self.assertTrue(truffleHog.path_included(blob, include_patterns=deleted_paths_patterns),
+                self.assertTrue(truffleHog.path_included(blob_path, include_patterns=deleted_paths_patterns),
                                 '{}: inclusion should match deleted paths: {}'.format(blob, deleted_paths_patterns))
-                self.assertFalse(truffleHog.path_included(blob, exclude_patterns=deleted_paths_patterns),
+                self.assertFalse(truffleHog.path_included(blob_path, exclude_patterns=deleted_paths_patterns),
                                  '{}: exclusion should match deleted paths: {}'.format(blob, deleted_paths_patterns))
 
 

--- a/truffleHog/truffleHog.py
+++ b/truffleHog/truffleHog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import

--- a/truffleHog/truffleHog.py
+++ b/truffleHog/truffleHog.py
@@ -76,6 +76,8 @@ def main():
         if not args.log_level:
             args.log_level = "WARNING"
         logging.basicConfig(filename=args.log_file, format="%(asctime)s %(levelname)s: %(message)s", level=args.log_level.upper())
+    logging.info("Started")
+
     rules = {}
     if args.rules:
         try:
@@ -191,6 +193,7 @@ class bcolors:
     UNDERLINE = '\033[4m'
 
 def clone_git_repo(git_url):
+    logging.info("Cloning repo: %s", git_url)
     project_path = tempfile.mkdtemp()
     Repo.clone_from(git_url, project_path)
     return project_path
@@ -252,14 +255,14 @@ def find_entropy(printableDiff, commit_time, branch_name, prev_commit, blob, com
             for string in base64_strings:
                 b64Entropy = shannon_entropy(string, BASE64_CHARS)
                 if b64Entropy > 4.5:
-                    logging.warn("Found base64 string \"%s\": \"%s\"", string, line)
+                    logging.warning("Found base64 string \"%s\": \"%s\"", string, line)
                     stringsFound.append(string)
                     printableDiff = printableDiff.replace(string, bcolors.WARNING + string + bcolors.ENDC)
                     summaryDiff += line.replace(string, bcolors.WARNING + string + bcolors.ENDC)
             for string in hex_strings:
                 hexEntropy = shannon_entropy(string, HEX_CHARS)
                 if hexEntropy > 3:
-                    logging.warn("Found hex string \"%s\": \"%s\"", string, line)
+                    logging.warning("Found hex string \"%s\": \"%s\"", string, line)
                     stringsFound.append(string)
                     printableDiff = printableDiff.replace(string, bcolors.WARNING + string + bcolors.ENDC)
                     summaryDiff += line.replace(string, bcolors.WARNING + string + bcolors.ENDC) + "\n"
@@ -301,7 +304,7 @@ def regex_check(printableDiff, commit_time, branch_name, prev_commit, blob, comm
         diff = printableDiff
         for m in secret_regexes[key].finditer(diff):
             line = get_line(diff, m)
-            logging.warn("Found regex %s: %s", key, line)
+            logging.warning("Found regex %s: %s", key, line)
             found_strings.append(m.group())
             printableDiff = printableDiff.replace(m.group(), bcolors.WARNING + str(m.group()) + bcolors.ENDC)
             summaryDiff += line.replace(m.group(), bcolors.WARNING + str(m.group()) + bcolors.ENDC) + "\n"

--- a/truffleHog/truffleHog.py
+++ b/truffleHog/truffleHog.py
@@ -336,7 +336,7 @@ def diff_worker(diff, curr_commit, prev_commit, branch_name, commitHash, custom_
             # For very large blobs look for slow regexes.
             if len(printableDiff) > 256000:
                 logging.info("      Allow: \"%s\"", key)
-            printableDiff = allow[key].sub('', printableDiff)
+            printableDiff = allow[key].sub(' [Allowed by: \"%s\"] ' % key, printableDiff)
         commit_time =  datetime.datetime.fromtimestamp(prev_commit.committed_date).strftime('%Y-%m-%d %H:%M:%S')
         foundIssues = []
         if do_entropy:

--- a/truffleHog/truffleHog.py
+++ b/truffleHog/truffleHog.py
@@ -75,6 +75,7 @@ def main():
     if args.log_level or args.log_file:
         if not args.log_level:
             args.log_level = "WARNING"
+        os.remove(args.log_file)
         logging.basicConfig(filename=args.log_file, format="%(asctime)s %(levelname)s: %(message)s", level=args.log_level.upper())
     logging.info("Started")
 

--- a/truffleHog/truffleHog.py
+++ b/truffleHog/truffleHog.py
@@ -75,7 +75,11 @@ def main():
     if args.log_level or args.log_file:
         if not args.log_level:
             args.log_level = "WARNING"
-        os.remove(args.log_file)
+        if os.path.exists(args.log_file):
+            try:
+                os.remove(args.log_file)
+            except OSError:
+                pass
         logging.basicConfig(filename=args.log_file, format="%(asctime)s %(levelname)s: %(message)s", level=args.log_level.upper())
     logging.info("Started")
 


### PR DESCRIPTION
* Add support for logging. This is critical when trying to resolve cases where TH hangs on a large file or commit. Previously there was no way to know what was causing the problem.
* Add support for TERSE log output. This includes only the first line of the commit and only matching lines in the diff. It makes it much easier to find simple false positives which should probably be added to the allowed list.
* Allowed expressions are not completely removed. This makes it easier to see removals in context as allowed expressions are replaced by "[Allowed by: "rulename"]".

# Also

* Also added a rule checking feature which will look for overly agressive allow rules but this needs more work before we can give it to other people. It was helpful in checking the existing allow regexes.
